### PR TITLE
Expand sections by pressing the row

### DIFF
--- a/src/app/shared/components/sidenav/sidenav.component.html
+++ b/src/app/shared/components/sidenav/sidenav.component.html
@@ -12,12 +12,8 @@
   </mat-tree-node>
   <mat-nested-tree-node *matTreeNodeDef="let node; when: hasChild">
     <li>
-      <div class="section-node">
-        <button
-          mat-icon-button
-          matTreeNodeToggle
-          [attr.aria-label]="'toggle ' + node.name"
-        >
+      <div class="section-node" matTreeNodeToggle>
+        <button mat-icon-button [attr.aria-label]="'toggle ' + node.name">
           <mat-icon class="mat-icon-rtl-mirror">
             {{ treeControl.isExpanded(node) ? "expand_more" : "chevron_right" }}
           </mat-icon>


### PR DESCRIPTION
Before, to display the sidenav categories, you had to click right on the drop-down icon. Now it can be done by pressing anywhere in the row