### PR TITLE
fix(Observable): Regular Expression

### DIFF
--- a/src/assets/doc/concepts/observables.md
+++ b/src/assets/doc/concepts/observables.md
@@ -339,7 +339,7 @@ Las notificaciones "Next" son las más importantes, y las más comunes: represen
 La mejor forma de expresar estas restricciones es mediante la Gramática Observable o Contract, escrita mediante una expresión regular:
 
 ```javascript
-next\*(error|complete)?
+(next)*(error|complete)?
 ```
 
 > En una Ejecución Observable, se pueden emitir desde cero a infinitas notificaciones. En el caso de que se diera una notificación "Error" o "Complete", ninguna otra notificación podrá emitirse a partir de ese momento.

--- a/src/assets/doc/concepts/observables.md
+++ b/src/assets/doc/concepts/observables.md
@@ -339,7 +339,7 @@ Las notificaciones "Next" son las más importantes, y las más comunes: represen
 La mejor forma de expresar estas restricciones es mediante la Gramática Observable o Contract, escrita mediante una expresión regular:
 
 ```javascript
-(next)*(error|complete)?
+next*(error|complete)?
 ```
 
 > En una Ejecución Observable, se pueden emitir desde cero a infinitas notificaciones. En el caso de que se diera una notificación "Error" o "Complete", ninguna otra notificación podrá emitirse a partir de ese momento.


### PR DESCRIPTION
In my opinion the RegExp should be "next*(complete|error)?" instead of "next\*(complete | error)?" because the symbol "\" is use as escape in RegExp in several programming languages. In addition, the use of parenthesis "( )" with the wildcard "*" is more easy to understand.

So, I recommend use the following RegExp:

```
(next)*(complete | error) ?
```
